### PR TITLE
generalize pytorch-test finding logic

### DIFF
--- a/test/test_pytorch_common.py
+++ b/test/test_pytorch_common.py
@@ -10,8 +10,8 @@ import sys
 import torch
 import torch.autograd.function as function
 
-_root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-sys.path.insert(-1, os.path.join(_root_dir, "repos", "pytorch", "test"))
+_root_dir = os.path.dirname(os.path.dirname(os.path.realpath(torch.__file__)))
+sys.path.insert(-1, os.path.join(_root_dir, "test"))
 
 from common import *
 


### PR DESCRIPTION
it now works even if the pytorch repo is located somewhere other than
the repos/ subdirectory