### PR TITLE
Fix for scalars in pytorch.

### DIFF
--- a/test/expect/TestOperators.test_mean.expect
+++ b/test/expect/TestOperators.test_mean.expect
@@ -36,9 +36,6 @@ graph {
       tensor_type {
         elem_type: FLOAT
         shape {
-          dim {
-            dim_value: 1
-          }
         }
       }
     }

--- a/test/expect/TestOperators.test_prod.expect
+++ b/test/expect/TestOperators.test_prod.expect
@@ -41,9 +41,6 @@ graph {
       tensor_type {
         elem_type: FLOAT
         shape {
-          dim {
-            dim_value: 1
-          }
         }
       }
     }

--- a/test/expect/TestOperators.test_sum.expect
+++ b/test/expect/TestOperators.test_sum.expect
@@ -36,9 +36,6 @@ graph {
       tensor_type {
         elem_type: FLOAT
         shape {
-          dim {
-            dim_value: 1
-          }
         }
       }
     }


### PR DESCRIPTION
This is necessary (not sure if it's sufficient) for when we turn on scalars in PyTorch.  See corresponding PyTorch PR: https://github.com/pytorch/pytorch/pull/4855.  We need to merge these at the same time.