### PR TITLE
Fix BatchNorm2d test using inputs of wrong number of dimensions

### DIFF
--- a/test/expect/TestOperators.test_batchnorm.expect
+++ b/test/expect/TestOperators.test_batchnorm.expect
@@ -40,7 +40,7 @@ graph {
     dims: 2
     data_type: FLOAT
     name: "1"
-    raw_data: "\217~,?b\265\251>"
+    raw_data: "\330=\221>|\037(?"
   }
   initializer {
     dims: 2
@@ -66,6 +66,12 @@ graph {
       tensor_type {
         elem_type: FLOAT
         shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
           dim {
             dim_value: 2
           }
@@ -134,6 +140,12 @@ graph {
       tensor_type {
         elem_type: FLOAT
         shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
           dim {
             dim_value: 2
           }

--- a/test/expect/TestOperators.test_batchnorm_training.expect
+++ b/test/expect/TestOperators.test_batchnorm_training.expect
@@ -44,7 +44,7 @@ graph {
     dims: 2
     data_type: FLOAT
     name: "1"
-    raw_data: "\217~,?b\265\251>"
+    raw_data: "\330=\221>|\037(?"
   }
   initializer {
     dims: 2
@@ -70,6 +70,12 @@ graph {
       tensor_type {
         elem_type: FLOAT
         shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
           dim {
             dim_value: 2
           }
@@ -138,6 +144,12 @@ graph {
       tensor_type {
         elem_type: FLOAT
         shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
           dim {
             dim_value: 2
           }

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -197,11 +197,11 @@ class TestOperators(TestCase):
 
     # TODO: Do an nn style test for these
     def test_batchnorm(self):
-        x = Variable(torch.randn(2, 2).fill_(1.0), requires_grad=True)
+        x = Variable(torch.randn(2, 2, 2, 2).fill_(1.0), requires_grad=True)
         self.assertONNX(nn.BatchNorm2d(2), x)
 
     def test_batchnorm_training(self):
-        x = Variable(torch.randn(2, 2).fill_(1.0), requires_grad=True)
+        x = Variable(torch.randn(2, 2, 2, 2).fill_(1.0), requires_grad=True)
         self.assertONNX(nn.BatchNorm2d(2), x, training=True)
 
     def test_conv(self):


### PR DESCRIPTION
BatchNorm2d should see 4d inputs. The onnx-fb-universe test in https://github.com/pytorch/pytorch/pull/4922 fails because that PR restores dimensionality check in BN modules.