### PR TITLE
ONNX fixes for Variable and Tensor merge

### DIFF
--- a/test/model_defs/inception.py
+++ b/test/model_defs/inception.py
@@ -36,7 +36,7 @@ class Inception3(nn.Module):
                 stddev = m.stddev if hasattr(m, 'stddev') else 0.1
                 X = stats.truncnorm(-2, 2, scale=stddev)
                 values = torch.Tensor(X.rvs(m.weight.data.numel()))
-                m.weight.data.copy_(values)
+                m.weight.data.copy_(values.view_as(m.weight))
             elif isinstance(m, nn.BatchNorm2d):
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()

--- a/test/verify.py
+++ b/test/verify.py
@@ -285,7 +285,7 @@ def verify(model, args, backend, verbose=False, training=False, decimal=3, test_
         # are likely to be things like indices, where just randomly
         # spattering some longs is unlikely to work.  One way we could
         # make this work is to apply a random permutation or something.
-        if hasattr(new_data, 'uniform_'):
+        if arg.is_floating_point():
             new_data.uniform_()
         return torch.autograd.Variable(new_data, volatile=arg.volatile, requires_grad=arg.requires_grad)
 


### PR DESCRIPTION
```
 * Tensor.copy_() requires broadcasting semantics
 * hasattr() is not a reliable method for determining if a function is
   implemented on a type. Use is_floating_point() instead.
```