### PR TITLE
Use regex matching instead of expect files for export failures

### DIFF
--- a/test/expect/TestOperators.test_add_left_broadcast.expect
+++ b/test/expect/TestOperators.test_add_left_broadcast.expect
@@ -1,9 +1,0 @@
-ONNX export failed: Couldn't export operator expand; this usually means you used a form of broadcasting that ONNX does not currently support
-
-Graph we tried to export:
-graph(%0 : Double(3)
-      %1 : Double(2, 3)) {
-  %2 : Double(2!, 3) = Expand[shape=[2, 3]](%0), scope: FuncModule
-  %3 : Double(2, 3) = Add(%2, %1), scope: FuncModule
-  return (%3);
-}

--- a/test/expect/TestOperators.test_add_size1_broadcast.expect
+++ b/test/expect/TestOperators.test_add_size1_broadcast.expect
@@ -1,9 +1,0 @@
-ONNX export failed: Couldn't export operator expand; this usually means you used a form of broadcasting that ONNX does not currently support
-
-Graph we tried to export:
-graph(%0 : Double(2, 3)
-      %1 : Double(2, 1)) {
-  %2 : Double(2!, 3!) = Expand[shape=[2, 3]](%1), scope: FuncModule
-  %3 : Double(2, 3) = Add(%0, %2), scope: FuncModule
-  return (%3);
-}

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -96,6 +96,14 @@ class TestOperators(TestCase):
             m = FuncModule(f, params)
         self.assertExpectedRaises(err, lambda: export_to_string(m, args, **kwargs))
 
+    def assertONNXRaisesRegex(self, err, reg, f, args, params=tuple(), **kwargs):
+        if isinstance(f, nn.Module):
+            m = f
+        else:
+            m = FuncModule(f, params)
+        with self.assertRaisesRegex(err, reg):
+            export_to_string(m, args, **kwargs)
+
     def test_basic(self):
         x = Variable(torch.Tensor([0.4]), requires_grad=True)
         y = Variable(torch.Tensor([0.7]), requires_grad=True)
@@ -125,12 +133,16 @@ class TestOperators(TestCase):
     def test_add_left_broadcast(self):
         x = Variable(torch.DoubleTensor(3), requires_grad=True)
         y = Variable(torch.DoubleTensor(2, 3), requires_grad=True)
-        self.assertONNXRaises(RuntimeError, lambda x, y: x + y, (x, y))
+        self.assertONNXRaisesRegex(RuntimeError, 
+            'ONNX export failed: Couldn\'t export operator expand.*',
+            lambda x, y: x + y, (x, y))
 
     def test_add_size1_broadcast(self):
         x = Variable(torch.DoubleTensor(2, 3), requires_grad=True)
         y = Variable(torch.DoubleTensor(2, 1), requires_grad=True)
-        self.assertONNXRaises(RuntimeError, lambda x, y: x + y, (x, y))
+        self.assertONNXRaisesRegex(RuntimeError,
+            'ONNX export failed: Couldn\'t export operator expand.*',
+            lambda x, y: x + y, (x, y))
 
     def test_transpose(self):
         x = Variable(torch.Tensor([[0, 1], [2, 3]]), requires_grad=True)

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -134,14 +134,14 @@ class TestOperators(TestCase):
         x = Variable(torch.DoubleTensor(3), requires_grad=True)
         y = Variable(torch.DoubleTensor(2, 3), requires_grad=True)
         self.assertONNXRaisesRegex(RuntimeError, 
-            'ONNX export failed: Couldn\'t export operator expand.*',
+            r"ONNX export failed: Couldn't export operator expand.*",
             lambda x, y: x + y, (x, y))
 
     def test_add_size1_broadcast(self):
         x = Variable(torch.DoubleTensor(2, 3), requires_grad=True)
         y = Variable(torch.DoubleTensor(2, 1), requires_grad=True)
         self.assertONNXRaisesRegex(RuntimeError,
-            'ONNX export failed: Couldn\'t export operator expand.*',
+            r"ONNX export failed: Couldn't export operator expand.*",
             lambda x, y: x + y, (x, y))
 
     def test_transpose(self):


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/5652 introduces a change in which we print provenance stack traces for an op when we fail to export that op. This makes the test cases assert that a regex is matched for the exception, to stabilize ourselves against the stack traces being different on every machine