### PR TITLE
Skip RNN tests with dropout > 0 and num_layers = 1 

### DIFF
--- a/test/test_caffe2.py
+++ b/test/test_caffe2.py
@@ -696,6 +696,8 @@ def setup_rnn_tests():
         # disable some combinations
         if bidirectional[0] and variable_length[0] == 0:
             continue
+        if dropout > 0 and layer == 1:
+            continue
 
         for base, name, extra_kwargs in (
                 ('elman', 'elman_relu', { 'nonlinearity' : u'relu' }),


### PR DESCRIPTION
Skip because dropout has no effect with num_layers = 1. This is blocking https://github.com/pytorch/pytorch/pull/6079.