### PR TITLE
Fix test_pad to use valid pad amount for reflective padding

### DIFF
--- a/test/expect/TestOperators.test_pad.expect
+++ b/test/expect/TestOperators.test_pad.expect
@@ -15,12 +15,12 @@ graph {
       name: "pads"
       ints: 0
       ints: 0
-      ints: 1
-      ints: 3
-      ints: 0
       ints: 0
       ints: 2
-      ints: 4
+      ints: 0
+      ints: 0
+      ints: 1
+      ints: 3
       type: INTS
     }
   }
@@ -60,10 +60,10 @@ graph {
             dim_value: 1
           }
           dim {
-            dim_value: 5
+            dim_value: 3
           }
           dim {
-            dim_value: 11
+            dim_value: 9
           }
         }
       }

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -182,7 +182,7 @@ class TestOperators(TestCase):
 
     def test_pad(self):
         x = Variable(torch.Tensor([[[[0, 1, 1, 1], [2, 3, 7, 7]]]]), requires_grad=True)
-        self.assertONNX(nn.ReflectionPad2d((3, 4, 1, 2)), x)
+        self.assertONNX(nn.ReflectionPad2d((2, 3, 1, 2)), x)
 
     def test_params(self):
         x = Variable(torch.Tensor([[1, 2], [3, 4]]), requires_grad=True)

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -182,7 +182,7 @@ class TestOperators(TestCase):
 
     def test_pad(self):
         x = Variable(torch.Tensor([[[[0, 1, 1, 1], [2, 3, 7, 7]]]]), requires_grad=True)
-        self.assertONNX(nn.ReflectionPad2d((2, 3, 1, 2)), x)
+        self.assertONNX(nn.ReflectionPad2d((2, 3, 0, 1)), x)
 
     def test_params(self):
         x = Variable(torch.Tensor([[1, 2], [3, 4]]), requires_grad=True)


### PR DESCRIPTION
The input has shape `1 x 1 x 2 x 4`. Reflectively padding the last dimension with amount `4` is invalid, and is now a hard error after https://github.com/pytorch/pytorch/pull/6438.

Padding the second last with amount `2` is also invalid.