### PR TITLE
Avoid using torch.autograd.function._* nonpublic API

### DIFF
--- a/test/test_pytorch_common.py
+++ b/test/test_pytorch_common.py
@@ -39,4 +39,4 @@ skipIfCI = _skipper(lambda: os.getenv('CI'),
                     'Skip In CI')
 
 def flatten(x):
-    return tuple(function._iter_filter(lambda o: isinstance(o, Variable) or torch.is_tensor(o))(x))
+    return tuple(function._iter_filter(lambda o: isinstance(o, torch.Tensor))(x))


### PR DESCRIPTION
The current code makes it impossible to change the name/behavior of these functions on PyTorch side because `onnx-fb-unversion` will fail, e.g. https://github.com/pytorch/pytorch/pull/6641 (PR) https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-cuda9-cudnn7-py2-test/6130/console (error).

This PR copies `_nested_map` and `_iter_filter` from PyTorch source to here so that they don't rely on private API.

Unblocks https://github.com/pytorch/pytorch/pull/6641.